### PR TITLE
Failing tests

### DIFF
--- a/Sanity/auditing/runtest.sh
+++ b/Sanity/auditing/runtest.sh
@@ -64,6 +64,7 @@ rlJournalStart && {
       > /var/log/usbguard/usbguard-audit.log
       set_config_option AuditBackend FileAudit
       rlRun "rlServiceStart usbguard"
+      rlRun "sleep 3s"
       rlRun -s "cat /var/log/usbguard/usbguard-audit.log"
       rlAssertGrep "result='SUCCESS" $rlRun_LOG
       rm -f $rlRun_LOG
@@ -79,6 +80,7 @@ rlJournalStart && {
       > /var/log/usbguard/usbguard-audit.log
       set_config_option AuditBackend LinuxAudit
       rlRun "rlServiceStart usbguard"
+      rlRun "sleep 3s"
       rlRun -s "LC_ALL='en_US.UTF-8' ausearch --input-logs -m USER_DEVICE -ts $start_time" 0,1
       rlAssertGrep 'USER_DEVICE' $rlRun_LOG
       rm -f $rlRun_LOG

--- a/Sanity/config-sanity/configs/rhel10/etc/usbguard/usbguard-daemon.conf
+++ b/Sanity/config-sanity/configs/rhel10/etc/usbguard/usbguard-daemon.conf
@@ -1,0 +1,211 @@
+#
+# Rule set file path.
+#
+# The USBGuard daemon will use this file to load the policy
+# rule set from it and to write new rules received via the
+# IPC interface.
+#
+# RuleFile=/path/to/rules.conf
+#
+RuleFile=/etc/usbguard/rules.conf
+
+#
+# Rule set folder path.
+#
+# The USBGuard daemon will use this folder to load the policy
+# rule set from it and to write new rules received via the
+# IPC interface. Usually, we set the option to
+# /etc/usbguard/rules.d/. The USBGuard daemon is supposed to
+# behave like any other standard Linux daemon therefore it
+# loads rule files in alpha-numeric order. File names inside
+# RuleFolder directory should start with a two-digit number
+# prefix indicating the position, in which the rules are
+# scanned by the daemon.
+#
+# RuleFolder=/path/to/rulesfolder/
+#
+RuleFolder=/etc/usbguard/rules.d/
+
+#
+# Implicit policy target.
+#
+# How to treat devices that don't match any rule in the
+# policy. One of:
+#
+# * allow  - authorize the device
+# * block  - block the device
+# * reject - remove the device
+#
+ImplicitPolicyTarget=block
+
+#
+# Present device policy.
+#
+# How to treat devices that are already connected when the
+# daemon starts. One of:
+#
+# * allow        - authorize every present device
+# * block        - deauthorize every present device
+# * reject       - remove every present device
+# * keep         - just sync the internal state and leave it
+# * apply-policy - evaluate the ruleset for every present
+#                  device
+#
+PresentDevicePolicy=apply-policy
+
+#
+# Present controller policy.
+#
+# How to treat USB controllers that are already connected
+# when the daemon starts. One of:
+#
+# * allow        - authorize every present device
+# * block        - deauthorize every present device
+# * reject       - remove every present device
+# * keep         - just sync the internal state and leave it
+# * apply-policy - evaluate the ruleset for every present
+#                  device
+#
+PresentControllerPolicy=keep
+
+#
+# Inserted device policy.
+#
+# How to treat USB devices that are already connected
+# *after* the daemon starts. One of:
+#
+# * block        - deauthorize every present device
+# * reject       - remove every present device
+# * apply-policy - evaluate the ruleset for every present
+#                  device
+#
+InsertedDevicePolicy=apply-policy
+
+#
+# Control which devices are authorized by default.
+#
+# The USBGuard daemon modifies some the default authorization state attributes
+# of controller devices. This setting, enables you to define what value the
+# default authorization is set to.
+#
+# * keep         - do not change the authorization state
+# * none         - every new device starts out deauthorized
+# * all          - every new device starts out authorized
+# * internal     - internal devices start out authorized, external devices start
+#                  out deauthorized (this requires the ACPI tables to properly
+#                  label internal devices, and kernel support)
+#
+#AuthorizedDefault=none
+
+#
+# Restore controller device state.
+#
+# The USBGuard daemon modifies some attributes of controller
+# devices like the default authorization state of new child device
+# instances. Using this setting, you can control whether the
+# daemon will try to restore the attribute values to the state
+# before modification on shutdown.
+#
+# SECURITY CONSIDERATIONS: If set to true, the USB authorization
+# policy could be bypassed by performing some sort of attack on the
+# daemon (via a local exploit or via a USB device) to make it shutdown
+# and restore to the operating-system default state (known to be permissive).
+#
+RestoreControllerDeviceState=false
+
+#
+# Device manager backend
+#
+# Which device manager backend implementation to use. One of:
+#
+# * uevent   - Netlink based implementation which uses sysfs to scan for present
+#              devices and an uevent netlink socket for receiving USB device
+#              related events.
+# * umockdev - umockdev based device manager capable of simulating devices based
+#              on umockdev-record files. Useful for testing.
+#
+DeviceManagerBackend=uevent
+
+#!!! WARNING: It's good practice to set at least one of the !!!
+#!!!          two options bellow. If none of them are set,  !!!
+#!!!          the daemon will accept IPC connections from   !!!
+#!!!          anyone, thus allowing anyone to modify the    !!!
+#!!!          rule set and (de)authorize USB devices.       !!!
+
+#
+# Users allowed to use the IPC interface.
+#
+# A space delimited list of usernames that the daemon will
+# accept IPC connections from.
+#
+# IPCAllowedUsers=username1 username2 ...
+#
+IPCAllowedUsers=root
+
+#
+# Groups allowed to use the IPC interface.
+#
+# A space delimited list of groupnames that the daemon will
+# accept IPC connections from.
+#
+# IPCAllowedGroups=groupname1 groupname2 ...
+#
+IPCAllowedGroups=wheel
+
+#
+# IPC access control definition files path.
+#
+# The files at this location will be interpreted by the daemon
+# as access control definition files. The (base)name of a file
+# should be in the form:
+#
+#   [user][:<group>]
+#
+# and should contain lines in the form:
+#
+#   <section>=[privilege] ...
+#
+# This way each file defines who is able to connect to the IPC
+# bus and what privileges he has.
+#
+IPCAccessControlFiles=/etc/usbguard/IPCAccessControl.d/
+
+#
+# Generate device specific rules including the "via-port"
+# attribute.
+#
+# This option modifies the behavior of the allowDevice
+# action. When instructed to generate a permanent rule,
+# the action can generate a port specific rule. Because
+# some systems have unstable port numbering, the generated
+# rule might not match the device after rebooting the system.
+#
+# If set to false, the generated rule will still contain
+# the "parent-hash" attribute which also defines an association
+# to the parent device. See usbguard-rules.conf(5) for more
+# details.
+#
+DeviceRulesWithPort=false
+
+#
+# USBGuard Audit events log backend
+#
+# One of:
+#
+# * FileAudit - Log audit events into a file specified by
+#               AuditFilePath setting (see below)
+# * LinuxAudit - Log audit events using the Linux Audit
+#                subsystem (using audit_log_user_message)
+#
+AuditBackend=FileAudit
+
+#
+# USBGuard audit events log file path.
+#
+AuditFilePath=/var/log/usbguard/usbguard-audit.log
+
+#
+# Hides personally identifiable information such as device serial numbers and
+# hashes of descriptors (which include the serial number) from audit entries.
+#
+HidePII=false

--- a/Sanity/inter-package-dependency/runtest.sh
+++ b/Sanity/inter-package-dependency/runtest.sh
@@ -47,7 +47,7 @@ rlJournalStart && {
       rlAssertNotGrep '\\busbguard\\b' $rlRun_LOG -Eq
       rm -f $rlRun_LOG
       rlRun -s "rpm -q --recommends usbguard"
-      rlAssertGrep 'usbguard-selinux[^0-9]*$' $rlRun_LOG
+      rlAssertGrep 'usbguard-selinux[^0-9]*' $rlRun_LOG
       rm -f $rlRun_LOG
       rlRun -s "rpm -q --conflicts usbguard"
       rlAssertNotGrep '^usbguard$' $rlRun_LOG

--- a/Sanity/service-sanity/runtest.sh
+++ b/Sanity/service-sanity/runtest.sh
@@ -84,7 +84,7 @@ rlJournalStart
         rlRun "systemctl daemon-reexec"
         rlRun "rlServiceStart usbguard"
         rlRun -s "journalctl --no-pager --since=\"$start_time\""
-		rlRun "systemctl is-active usbguard"
+        rlRun "systemctl is-active usbguard"
 
         rlAssertNotGrep "IPAddressDeny" $rlRun_LOG
         rm -rf $rlRun_LOG

--- a/Sanity/service-sanity/runtest.sh
+++ b/Sanity/service-sanity/runtest.sh
@@ -79,19 +79,16 @@ rlJournalStart
     rlPhaseEnd
 
     rlPhaseStartTest "IPAddressDeny, bz1929364" && {
-      start_time=$(date +"%F %T")
-      rlRun "systemctl daemon-reload"
-      rlRun "systemctl daemon-reexec"
-      rlRun "rlServiceStart usbguard"
-      rlRun -s "journalctl --no-pager --since=\"$start_time\""
-      if rlIsFedora; then
-          rlAssertGrep "Started usbguard.service - USBGuard daemon" $rlRun_LOG
-      else
-          rlAssertGrep "Started USBGuard daemon" $rlRun_LOG
-      fi
-      rlAssertNotGrep "IPAddressDeny" $rlRun_LOG
-      rm -rf $rlRun_LOG
-      rlRun "rlServiceStatus usbguard"
+        start_time=$(date +"%F %T")
+        rlRun "systemctl daemon-reload"
+        rlRun "systemctl daemon-reexec"
+        rlRun "rlServiceStart usbguard"
+        rlRun -s "journalctl --no-pager --since=\"$start_time\""
+		rlRun "systemctl is-active usbguard"
+
+        rlAssertNotGrep "IPAddressDeny" $rlRun_LOG
+        rm -rf $rlRun_LOG
+        rlRun "rlServiceStatus usbguard"
     rlPhaseEnd; }
 
     rlPhaseStartCleanup


### PR DESCRIPTION
Sanity/service-sanity/runtest.sh: Use more general approach on checking if service is active
Sanity/inter-package-dependency/runtest.sh: Do not check for a concrete version of usbguard when checking with `rpm -q --requires`
Sanity/config-sanity/configs/rhel10/etc/usbguard/usbguard-daemon.conf: add missing config for rhel10
Sanity/auditing/runtest.sh: add delay after starting usbguard, so we can catch all audit logs