### PR TITLE
Failing tests review

### DIFF
--- a/Sanity/1738590-rebase-usbguard-to-0.7.8/runtest.sh
+++ b/Sanity/1738590-rebase-usbguard-to-0.7.8/runtest.sh
@@ -44,7 +44,7 @@ rlJournalStart
             key=$1
             value=$2
             rlLog "setting config option $key=$value"
-            egrep -E "^$key=.*" $CONFIG
+            grep -E "^$key=.*" $CONFIG
             if [ $? -eq 0 ]; then
                 sed -i -r  "s|^($key)=.*|\1=$value|" $CONFIG
             else
@@ -320,10 +320,10 @@ rlJournalStart
     #   [P2] AC: following values are accepted: "hardwired", "hotplug", "not used", "unknown", ""
     rlPhaseStartTest "New rule attribute: with-connect-type" && {
         regex='\"[^\"]*\"'
-        rlRun -s "usbguard generate-policy | egrep -o \"with-connect-type $regex\" | cut -d' ' -f2-" 0 "Create a list of attributes consisting of only with-connect-type"
+        rlRun -s "usbguard generate-policy | grep -E -o \"with-connect-type $regex\" | cut -d' ' -f2-" 0 "Create a list of attributes consisting of only with-connect-type"
         while IFS='' read -r line; do
             regex='^"(hotplug|hardwired|not used|unknown)?"$'
-            rlRun "echo $line | egrep $regex" 0 "$line should be match $regex"
+            rlRun "echo $line | grep -E $regex" 0 "$line should be match $regex"
         done < $rlRun_LOG
     rlPhaseEnd; }
 


### PR DESCRIPTION
1. Replace deprecated `egrep` with `grep -E`
2. Use `systemctl is-active` and similar more general approach. The previous approach depended on the output of systemctl status command, but there is no guarantee that this will remain in a certain output format. 