### PR TITLE
Add missing descriptions to main.fmf test cases

### DIFF
--- a/Library/usbguard-basic/main.fmf
+++ b/Library/usbguard-basic/main.fmf
@@ -1,5 +1,6 @@
 summary: usbguard basic functions
-description: Beakerlib library implementing various usbguard related functions 
+description: |
+    Beakerlib library implementing various usbguard related functions
     that should simplify test implementation.
 contact: Patrik Koncity <pkoncity@redhat.com>
 component: []

--- a/Regression/bz2005020-IPC-permissions-validations/main.fmf
+++ b/Regression/bz2005020-IPC-permissions-validations/main.fmf
@@ -1,7 +1,9 @@
 summary: test usbguard IPC handling via cli
-description: Verify that usbguard add-user validates IPC permission inputs correctly,
-    rejects invalid privileges per section, expands the ALL keyword properly, and
-    documents all valid privilege strings in the man pages.
+description: |
+    Verify that usbguard add-user validates IPC permission inputs
+    correctly, rejects invalid privileges per section, expands the
+    ALL keyword properly, and documents all valid privilege strings
+    in the man pages.
 extra-summary: /usbguard/Regression/bz2005020-IPC-permissions-validations
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh

--- a/Regression/bz2005020-IPC-permissions-validations/main.fmf
+++ b/Regression/bz2005020-IPC-permissions-validations/main.fmf
@@ -1,4 +1,7 @@
 summary: test usbguard IPC handling via cli
+description: Verify that usbguard add-user validates IPC permission inputs correctly,
+    rejects invalid privileges per section, expands the ALL keyword properly, and
+    documents all valid privilege strings in the man pages.
 extra-summary: /usbguard/Regression/bz2005020-IPC-permissions-validations
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh

--- a/Regression/legacy-file-path-in-unit-file/main.fmf
+++ b/Regression/legacy-file-path-in-unit-file/main.fmf
@@ -1,4 +1,6 @@
 summary: Legacy file path in unit file
+description: Verify that starting the usbguard service does not produce legacy
+    directory path warnings in the systemd journal.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Regression/legacy-file-path-in-unit-file/main.fmf
+++ b/Regression/legacy-file-path-in-unit-file/main.fmf
@@ -1,6 +1,7 @@
 summary: Legacy file path in unit file
-description: Verify that starting the usbguard service does not produce legacy
-    directory path warnings in the systemd journal.
+description: |
+    Verify that starting the usbguard service does not produce
+    legacy directory path warnings in the systemd journal.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Regression/package-integrity/main.fmf
+++ b/Regression/package-integrity/main.fmf
@@ -1,8 +1,9 @@
 summary: Check integrity of package - correct installation and permissions of the
     package files
-description: Check there are no errors during package installation as in RHEL-113206.
-    Check permissions were updated to 0755 based and no mismatch is caused, based
-    on RHEL-92260.
+description: |
+    Check there are no errors during package installation as in
+    RHEL-113206. Check permissions were updated to 0755 based and
+    no mismatch is caused, based on RHEL-92260.
 contact: Natália Bubáková <nbubakov@redhat.com>
 test: ./runtest.sh
 duration: 5m

--- a/Sanity/IPCACL/main.fmf
+++ b/Sanity/IPCACL/main.fmf
@@ -1,3 +1,6 @@
+description: Verify that usbguard IPC access control correctly enforces per-user,
+    per-group, primary group, and supplementary group permissions for device, policy,
+    and parameter operations.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 enabled: true
 require+:

--- a/Sanity/IPCACL/main.fmf
+++ b/Sanity/IPCACL/main.fmf
@@ -1,6 +1,7 @@
-description: Verify that usbguard IPC access control correctly enforces per-user,
-    per-group, primary group, and supplementary group permissions for device, policy,
-    and parameter operations.
+description: |
+    Verify that usbguard IPC access control correctly enforces
+    per-user, per-group, primary group, and supplementary group
+    permissions for device, policy, and parameter operations.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 enabled: true
 require+:

--- a/Sanity/OOM/main.fmf
+++ b/Sanity/OOM/main.fmf
@@ -1,4 +1,5 @@
-description: test OOM settings
+description: |
+    test OOM settings
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 5m

--- a/Sanity/auditing/main.fmf
+++ b/Sanity/auditing/main.fmf
@@ -1,3 +1,6 @@
+description: Verify that usbguard audit events are correctly routed to either the
+    file-based audit log or the Linux Audit subsystem depending on the configured
+    AuditBackend setting.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 5m

--- a/Sanity/auditing/main.fmf
+++ b/Sanity/auditing/main.fmf
@@ -1,6 +1,7 @@
-description: Verify that usbguard audit events are correctly routed to either the
-    file-based audit log or the Linux Audit subsystem depending on the configured
-    AuditBackend setting.
+description: |
+    Verify that usbguard audit events are correctly routed to
+    either the file-based audit log or the Linux Audit subsystem
+    depending on the configured AuditBackend setting.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 duration: 5m

--- a/Sanity/bz1772149-try-to-parse-match-all-rule/main.fmf
+++ b/Sanity/bz1772149-try-to-parse-match-all-rule/main.fmf
@@ -1,5 +1,6 @@
 summary: Tryies to parse match-all rule
-description: ''
+description: Verify that the usbguard-rule-parser correctly parses a match-all rule
+    with wildcard device ID and multiple interface classes.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/bz1772149-try-to-parse-match-all-rule/main.fmf
+++ b/Sanity/bz1772149-try-to-parse-match-all-rule/main.fmf
@@ -1,6 +1,8 @@
 summary: Tryies to parse match-all rule
-description: Verify that the usbguard-rule-parser correctly parses a match-all rule
-    with wildcard device ID and multiple interface classes.
+description: |
+    Verify that the usbguard-rule-parser correctly parses a
+    match-all rule with wildcard device ID and multiple interface
+    classes.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/config-sanity/main.fmf
+++ b/Sanity/config-sanity/main.fmf
@@ -1,7 +1,9 @@
 summary: tries out valid and invalid config file keywords
-description: Verify that the usbguard daemon correctly rejects invalid configuration
-    directive names and values, and properly handles RuleFile and RuleFolder settings
-    including their interaction and rule ordering.
+description: |
+    Verify that the usbguard daemon correctly rejects invalid
+    configuration directive names and values, and properly handles
+    RuleFile and RuleFolder settings including their interaction
+    and rule ordering.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require:

--- a/Sanity/config-sanity/main.fmf
+++ b/Sanity/config-sanity/main.fmf
@@ -1,5 +1,7 @@
 summary: tries out valid and invalid config file keywords
-description: ''
+description: Verify that the usbguard daemon correctly rejects invalid configuration
+    directive names and values, and properly handles RuleFile and RuleFolder settings
+    including their interaction and rule ordering.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require:

--- a/Sanity/dbus/main.fmf
+++ b/Sanity/dbus/main.fmf
@@ -1,3 +1,6 @@
+description: Verify that usbguard-dbus PolicyKit actions are present and that D-Bus
+    access control correctly enforces per-user and per-group permissions for parameter,
+    rule, and device management operations.
 contact: Attila Lakatos <alakatos@redhat.com>
 enabled: true
 require+:

--- a/Sanity/dbus/main.fmf
+++ b/Sanity/dbus/main.fmf
@@ -1,6 +1,8 @@
-description: Verify that usbguard-dbus PolicyKit actions are present and that D-Bus
-    access control correctly enforces per-user and per-group permissions for parameter,
-    rule, and device management operations.
+description: |
+    Verify that usbguard-dbus PolicyKit actions are present and
+    that D-Bus access control correctly enforces per-user and
+    per-group permissions for parameter, rule, and device
+    management operations.
 contact: Attila Lakatos <alakatos@redhat.com>
 enabled: true
 require+:

--- a/Sanity/inter-package-dependency/main.fmf
+++ b/Sanity/inter-package-dependency/main.fmf
@@ -1,4 +1,7 @@
 summary: Packages dependency relationship
+description: Verify that usbguard and usbguard-selinux RPM packages declare correct
+    dependency, recommends, and conflicts relationships with each other and with
+    selinux-policy-targeted.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/inter-package-dependency/main.fmf
+++ b/Sanity/inter-package-dependency/main.fmf
@@ -1,7 +1,8 @@
 summary: Packages dependency relationship
-description: Verify that usbguard and usbguard-selinux RPM packages declare correct
-    dependency, recommends, and conflicts relationships with each other and with
-    selinux-policy-targeted.
+description: |
+    Verify that usbguard and usbguard-selinux RPM packages declare
+    correct dependency, recommends, and conflicts relationships
+    with each other and with selinux-policy-targeted.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/rule-label/main.fmf
+++ b/Sanity/rule-label/main.fmf
@@ -1,4 +1,6 @@
 summary: Testing if usbguard list-rules --label "something" works properly
+description: Verify that usbguard list-rules --label correctly filters rules by
+    label attribute and does not fail when some rules lack the optional label field.
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
 require:

--- a/Sanity/rule-label/main.fmf
+++ b/Sanity/rule-label/main.fmf
@@ -1,6 +1,8 @@
 summary: Testing if usbguard list-rules --label "something" works properly
-description: Verify that usbguard list-rules --label correctly filters rules by
-    label attribute and does not fail when some rules lack the optional label field.
+description: |
+    Verify that usbguard list-rules --label correctly filters
+    rules by label attribute and does not fail when some rules
+    lack the optional label field.
 contact: Attila Lakatos <alakatos@redhat.com>
 test: ./runtest.sh
 require:

--- a/Sanity/rules-fuzz/main.fmf
+++ b/Sanity/rules-fuzz/main.fmf
@@ -1,5 +1,7 @@
 summary: performs fuzz testing on config/rules files
-description: ''
+description: Verify that the usbguard-rule-parser does not crash or hang when processing
+    fuzz-generated input by running AFL-based fuzz testing against an instrumented
+    build of usbguard-tools.
 contact: Dalibor Pospisil <dapospis@redhat.com>
 test: ./runtest.sh
 require:

--- a/Sanity/rules-fuzz/main.fmf
+++ b/Sanity/rules-fuzz/main.fmf
@@ -1,7 +1,8 @@
 summary: performs fuzz testing on config/rules files
-description: Verify that the usbguard-rule-parser does not crash or hang when processing
-    fuzz-generated input by running AFL-based fuzz testing against an instrumented
-    build of usbguard-tools.
+description: |
+    Verify that the usbguard-rule-parser does not crash or hang
+    when processing fuzz-generated input by running AFL-based fuzz
+    testing against an instrumented build of usbguard-tools.
 contact: Dalibor Pospisil <dapospis@redhat.com>
 test: ./runtest.sh
 require:

--- a/Sanity/rules-management/main.fmf
+++ b/Sanity/rules-management/main.fmf
@@ -1,4 +1,5 @@
-description: rules management in RuleFile and RuleFolder
+description: |
+    rules management in RuleFile and RuleFolder
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 require+:

--- a/Sanity/service-sanity/main.fmf
+++ b/Sanity/service-sanity/main.fmf
@@ -1,5 +1,7 @@
 summary: exercises usbguard service-related daemon functionality
-description: ''
+description: Verify that the usbguard service starts, stops, and restarts correctly,
+    fails gracefully on invalid rules configuration, and does not emit IPAddressDeny
+    warnings in the journal.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/service-sanity/main.fmf
+++ b/Sanity/service-sanity/main.fmf
@@ -1,7 +1,8 @@
 summary: exercises usbguard service-related daemon functionality
-description: Verify that the usbguard service starts, stops, and restarts correctly,
-    fails gracefully on invalid rules configuration, and does not emit IPAddressDeny
-    warnings in the journal.
+description: |
+    Verify that the usbguard service starts, stops, and restarts
+    correctly, fails gracefully on invalid rules configuration,
+    and does not emit IPAddressDeny warnings in the journal.
 contact: Dalibor Pospíšil <dapospis@redhat.com>
 test: ./runtest.sh
 recommend:

--- a/Sanity/usbguard-files-ownership/main.fmf
+++ b/Sanity/usbguard-files-ownership/main.fmf
@@ -1,5 +1,6 @@
 summary: Verify correct file ownership
-description: Verifies if important usbguard files have correct ownership
+description: |
+    Verifies if important usbguard files have correct ownership
 contact: Natália Bubáková <nbubakov@redhat.com>
 component:
   - usbguard


### PR DESCRIPTION
Add descriptions to test cases that had empty or missing description field in main.fmf.

## Summary by Sourcery

Documentation:
- Document currently undocumented or under-documented tests in various main.fmf files by adding descriptive summaries of their purpose.